### PR TITLE
Ruby's YAML Library

### DIFF
--- a/Sessions/config/sbt_config.yml
+++ b/Sessions/config/sbt_config.yml
@@ -45,8 +45,8 @@ folders:
 # (There are different formatting options depending on your Ruby version!)
 output:
   logfile:     scan.log
-  date format: %m/%d/%Y    # NOTE: ALL team members must use the same date format!
-  time format: %I:%M %p    # (print time in 12-hr format)
+  date format: '%m/%d/%Y'    # NOTE: ALL team members must use the same date format!
+  time format: '%I:%M %p'    # (print time in 12-hr format)
 #  time format: %H:%M       # (print time in 24-hr format)
 
 ###

--- a/Sessions/doc/examples/DecideRight/config/sbt_config.yml
+++ b/Sessions/doc/examples/DecideRight/config/sbt_config.yml
@@ -33,8 +33,8 @@ folders:
 # (There are different formatting options depending on your Ruby version!)
 output:
   logfile:     scan.log
-  date format: %m/%d/%Y    # NOTE: ALL team members must use the same format!
-  time format: %I:%M%p    # (print time in 12-hr format)
+  date format: '%m/%d/%Y'    # NOTE: ALL team members must use the same format!
+  time format: '%I:%M%p'    # (print time in 12-hr format)
 
 # All times are specified in minutes
 timebox:


### PR DESCRIPTION
Hey aquaman, how it's going? I'm requesting you a pull b/c I added a patch to allow run clr-sessions on ruby 1.9.3. The problem was the 'date format' & 'time format' fields, 1.8.7 allows %m/%d/%Y but 1.9.3 requires "'". For example, at 1.9.3
date format: %m/%d/%Y
is not allowed but
date format: '%m/%d/%Y'
is allowed.
At 1.8.7 works perfect '%m/%d/%Y' too. This code was tested w/ Ruby 1.8.7 & Ruby 1.9.3
Thanks a lot! and good hack;)
Nacho
